### PR TITLE
Setup deploy keys to allow r/w on the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ addons:
 before_install:
   - wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb -O pandoc.deb
   - sudo dpkg -i pandoc.deb
+  # ===========================
+  # Setting up SSH Deploy keys
+  # Run the ssh-agent
+  - eval $(ssh-agent -s)
+  # Add the private SSH key. tr is used to fix line endings
+  - echo "${SSH_PRIVATE_DEPLOY_KEY}" | openssl base64 -A -d | tr -d '\r' | ssh-add - > /dev/null
 
 install:
   - wget https://github.com/joypixels/emoji-assets/archive/v${EMOJIONE_VERSION}.tar.gz -O emojione-assets.tgz


### PR DESCRIPTION
Added a deploy key to allow the travis CI
pipeline to push on the repository. Had to encode
the private key to base64 so that travis CI doesn't bother the pipeline when escaping the environment variables. Added the decoding in the stage `before_install`.
Removed the verbose option for the ssh-add as it was only causing problems when running in the pipeline.